### PR TITLE
Update appengine_config.py to fix Click bug

### DIFF
--- a/appengine_config.py
+++ b/appengine_config.py
@@ -12,4 +12,8 @@ PRODUCTION_MODE = not os.environ.get(
 if not PRODUCTION_MODE:
     from google.appengine.tools.devappserver2.python import sandbox
     sandbox._WHITE_LIST_C_MODULES += ['_ctypes', 'gestalt']
-
+    import os
+    import sys
+    if os.name == 'nt':
+        os.name = None
+        sys.platform = ''


### PR DESCRIPTION
This will fix msvcrt import error in Click on the windows platform:
https://github.com/pallets/click/issues/594

This fix is similar to the one used here:
https://github.com/gae-init/gae-init/pull/527
